### PR TITLE
do not allow unverified users to login

### DIFF
--- a/gapi/rpc_create_user_test.go
+++ b/gapi/rpc_create_user_test.go
@@ -71,6 +71,23 @@ func randomUser(t *testing.T) (user db.User, password string) {
 
 }
 
+func randomVerifiedUser(t *testing.T) (user db.User, password string) {
+	password = util.RandomString(8)
+	hashedPassword, err := util.HashPassword(password)
+	require.NoError(t, err)
+
+	user = db.User{
+		Username:        util.RandomOwner(),
+		Role:            util.DepositorRole,
+		HashedPassword:  hashedPassword,
+		FullName:        util.RandomOwner(),
+		Email:           util.RandomEmail(),
+		IsEmailVerified: true,
+	}
+	return
+
+}
+
 func requireBodyMatchUser(t *testing.T, body *bytes.Buffer, user db.User) {
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)

--- a/gapi/rpc_login_user.go
+++ b/gapi/rpc_login_user.go
@@ -27,6 +27,10 @@ func (server *Server) LoginUser(ctx context.Context, req *pb.LoginUserRequest) (
 		return nil, status.Errorf(codes.Internal, "failed to find user: %s", err)
 	}
 
+	if !user.IsEmailVerified {
+		return nil, status.Errorf(codes.Unauthenticated, "user not email verified: %s", err)
+	}
+
 	err = util.CheckPassword(req.Password, user.HashedPassword)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "username and password do not match")


### PR DESCRIPTION
check if user is verified before checking password or any token or session is created